### PR TITLE
ci: fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,13 @@
 name: CI
-permissions:
-  contents: read
 
 on:
   pull_request: ~
   push:
     branches:
       - main
+
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
- [x] Addresses an existing open issue: fixes https://github.com/cylewaitforit/eslint-plugin-dependabot/security/code-scanning/10
- [x] That issue was marked as [`status: accepting prs`](https://github.com/cylewaitforit/eslint-plugin-dependabot/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/cylewaitforit/eslint-plugin-dependabot/blob/main/.github/CONTRIBUTING.md) were taken

Potential fix for [https://github.com/cylewaitforit/eslint-plugin-dependabot/security/code-scanning/10](https://github.com/cylewaitforit/eslint-plugin-dependabot/security/code-scanning/10)

To fix the problem, you should explicitly set the minimal required `permissions` for the workflow or for each job. The most secure and maintainable solution is to set `permissions:` at the workflow (root) level—applying to all jobs except those that need different permissions (none here do). For workflows that only check out code, build, run tests, or lint, only the `contents: read` permission is typically needed.  

To implement:  
- Add a `permissions:` block at the top-level of `.github/workflows/ci.yaml`, directly after `name: CI` and before `on:`, specifying `contents: read`.  
- This provides only read access to repository contents unless a job specifically needs more.  
- No additional imports, methods, or definitions are required.  
- No jobs here require write permission (e.g., issue updates, PR writing), so `contents: read` suffices.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
