### PR TITLE
ci: add dependabot skip to dedupe

### DIFF
--- a/.github/workflows/dependabot-dedupe.yaml
+++ b/.github/workflows/dependabot-dedupe.yaml
@@ -49,7 +49,7 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git add pnpm-lock.yaml
-          git commit -m 'chore: run pnpm dedupe'
+          git commit -m 'chore: run pnpm dedupe [dependabot skip]'
           git push
 
       - name: Remove label


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-dependabot! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #000
- [x] That issue was marked as [`status: accepting prs`](https://github.com/cylewaitforit/eslint-plugin-dependabot/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/cylewaitforit/eslint-plugin-dependabot/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Adds skip to dependabot dedupe commit so that dependabot can still update PRs.